### PR TITLE
add atom feed for news and planet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ if ENV['LSI'] == 'true'
 end
 
 group :jekyll_plugins do
+  gem 'jekyll-feed'
   gem 'jekyll-sitemap'
   gem 'jekyll-relative-links'
   gem 'jekyll-optional-front-matter'

--- a/_config.yml
+++ b/_config.yml
@@ -302,3 +302,7 @@ defaults:
       header:
         overlay_image: "/static/splash/galaxy-1.jpg"
         overlay_filter: 0.2
+
+
+plugins:
+  - jekyll-feed


### PR DESCRIPTION
I add atom feed for news and planet collections using the gem jekyll-feed.