### PR TITLE
Update 2025-03-16-Linux101-LIP-2025.md: Fix typos

### DIFF
--- a/pages/_news/2025/2025-03-16-Linux101-LIP-2025.md
+++ b/pages/_news/2025/2025-03-16-Linux101-LIP-2025.md
@@ -6,6 +6,8 @@ categories:
   - LUG 活动
 tags:
   - linux-install-party
+  - Linux 101
+  - LUG 活动
 ---
 
 # Linux Install Party 2025
@@ -20,7 +22,7 @@ tags:
 
 ![](https://ftp.lug.ustc.edu.cn/%E6%B4%BB%E5%8A%A8/2025.03.16_Linux_101_%E7%AC%AC%E4%B8%80%E8%AF%BE_Linux_Install_Party/IMG_7520.jpeg)
 
-在随后的实践环节中，社团成员分组指导参与者进行系统安装。无论是通过校内 VLab 平台远程体验，还是在虚拟机环境进行安装，亦或是实体设备的双系统部署，工作人员均针对不同需求提供个性化指导。现场同学通过互助协作，亲身体验 Linux 系统的安装流程。
+在随后的实践环节中，社团成员分组指导参与者进行系统安装。无论是通过校内 Vlab 平台远程体验，还是在虚拟机环境进行安装，亦或是实体设备的双系统部署，工作人员均针对不同需求提供个性化指导。现场同学通过互助协作，亲身体验 Linux 系统的安装流程。
 
 ![](https://ftp.lug.ustc.edu.cn/%E6%B4%BB%E5%8A%A8/2025.03.16_Linux_101_%E7%AC%AC%E4%B8%80%E8%AF%BE_Linux_Install_Party/IMG_7524.jpeg)
 

--- a/pages/_news/2025/2025-03-16-Linux101-LIP-2025.md
+++ b/pages/_news/2025/2025-03-16-Linux101-LIP-2025.md
@@ -10,7 +10,7 @@ tags:
 
 # Linux Install Party 2025
 
-2025 年 3 月 16 日下午，中国科学技术大学 Linux 用户协会在西区 3C101 教室成功举办 "Linux 101" 系列课程首讲——Linux Install Party。这是 LUG 第八年举办 Linux 101 系列课程、第九年举办 Linux Install Party。本次活动通过理论讲解与实践操作相结合的方式，帮助参与者初步了解 Linux 操作系统并完成安装实践。
+2025 年 3 月 16 日下午，中国科学技术大学学生 Linux 用户协会在西区 3C101 教室成功举办 "Linux 101" 系列课程首讲——Linux Install Party。这是 LUG 第八年举办 Linux 101 系列课程、第九年举办 Linux Install Party。本次活动通过理论讲解与实践操作相结合的方式，帮助参与者初步了解 Linux 操作系统并完成安装实践。
 
 ![](https://ftp.lug.ustc.edu.cn/%E6%B4%BB%E5%8A%A8/2025.03.16_Linux_101_%E7%AC%AC%E4%B8%80%E8%AF%BE_Linux_Install_Party/lip-post.jpg)
 
@@ -20,7 +20,7 @@ tags:
 
 ![](https://ftp.lug.ustc.edu.cn/%E6%B4%BB%E5%8A%A8/2025.03.16_Linux_101_%E7%AC%AC%E4%B8%80%E8%AF%BE_Linux_Install_Party/IMG_7520.jpeg)
 
-在随后的实践环节中，社团成员分组指导参与者进行系统安装。无论是通过校内 Vlab 平台远程体验，还是在虚拟机环境进行安装，亦或是实体设备的双系统部署，工作人员均针对不同需求提供个性化指导。现场同学通过互助协作，亲身体验 Linux 系统的安装流程。
+在随后的实践环节中，社团成员分组指导参与者进行系统安装。无论是通过校内 VLab 平台远程体验，还是在虚拟机环境进行安装，亦或是实体设备的双系统部署，工作人员均针对不同需求提供个性化指导。现场同学通过互助协作，亲身体验 Linux 系统的安装流程。
 
 ![](https://ftp.lug.ustc.edu.cn/%E6%B4%BB%E5%8A%A8/2025.03.16_Linux_101_%E7%AC%AC%E4%B8%80%E8%AF%BE_Linux_Install_Party/IMG_7524.jpeg)
 


### PR DESCRIPTION
Fix typo:

社团全称至少在第一次出现时使用；
`Vlab` -> `VLab`。